### PR TITLE
chore: update graphql-tag to 2.9.2

### DIFF
--- a/package.js
+++ b/package.js
@@ -23,7 +23,7 @@ Package.registerBuildPlugin({
   ],
   npmDependencies: {
     graphql: '0.12.3',
-    'graphql-tag': '2.6.1',
+    'graphql-tag': '2.9.2',
   },
 });
 


### PR DESCRIPTION
Fixes https://github.com/Swydo/meteor-graphql/issues/36