### PR TITLE
bump version, dependencies to be able to use latest graphql features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0
+
+- Updated `graphql` to `15.5.0`, adding support for latests graphql features
+- Updated `graphql-tag` to `2.11.0`, support for graphql 15.5.0
+
 ## 0.4.0
 
 - Updated `graphql` to `0.12.3`, adding support for string descriptors

--- a/package.js
+++ b/package.js
@@ -6,7 +6,7 @@ var packages = [
 
 Package.describe({
   name: 'swydo:graphql',
-  version: '0.4.0',
+  version: '1.0.0',
   summary: 'Compiler plugin that supports GraphQL files in Meteor',
   git: 'https://github.com/swydo/meteor-graphql',
   documentation: 'README.md',
@@ -22,8 +22,8 @@ Package.registerBuildPlugin({
     'plugin.js',
   ],
   npmDependencies: {
-    graphql: '0.12.3',
-    'graphql-tag': '2.9.2',
+    graphql: '15.5.0',
+    'graphql-tag': '2.11.0',
   },
 });
 


### PR DESCRIPTION
Hello there,

just wanted to use the latest features, so I bumped `graphql` and `graphql-tag` to latest versions.
